### PR TITLE
Stop background image from duplicating

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,9 +4,10 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  font-family: 'Open Sans', sans-serif;
+  font-family: "Open Sans", sans-serif;
   background: #222;
-  background-image: url('https://source.unsplash.com/1600x900/?landscape');
+  background-image: url("https://source.unsplash.com/1600x900/?landscape");
+  background-size: cover;
   font-size: 120%;
 }
 


### PR DESCRIPTION
As stated in issue #4 , the background image looked a little weird as when it was too small for the screen. I added a pretty simple style to make sure the image fills the viewport.

Before:
![image](https://user-images.githubusercontent.com/89240346/193437721-49eadd71-5905-44bc-a7dc-14d54470d30a.png)
After:
![image](https://user-images.githubusercontent.com/89240346/193437725-c6dd5eab-8d1a-4858-b6e6-e8ecaa2ec983.png)
